### PR TITLE
Add optional version prefix to prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action creates a tag with the build number in the repo, with optional versi
 - `prefix`: Prefix for tag. Default: 'build-number-'
 - `token`: GitHub token to create tag
 - `version_prefix`: Optional prefix to prefix :laughing:
-  - This is for uses who want tags such as '\<version\_number\>-build-number-\<build\_number\>',
+  - This is for uses who want tags such as '\<version\_number\>-build-number-\<build\_number\>',    
     e.g. '2.3.1-build-number-4'
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -16,27 +16,27 @@ This action creates a tag with the build number in the repo, with optional versi
 
 ## Example usage
 
-The following will create a tag 'build-\<build\_number\>'
+The following will create a tag 'build-\<build\_number\>':
 
 ```yaml
-uses: marohrdanz/build-number-tag@main
+uses: marohrdanz/build-number-tag@v1.0.0
 with:
   token: ${{ secrets.TOKEN }}
 ```
 
-The following will create a tag 'my-build-number-\<build\_number\>'
+The following will create a tag 'my-build-number-\<build\_number\>':
 
 ```yaml
-uses: marohrdanz/build-number-tag@main
+uses: marohrdanz/build-number-tag@v1.0.0
 with:
   prefix: 'my-build-number-'
   token: ${{ secrets.TOKEN }}
 ```
 
-The following will create a tag '3.4.2-my-build-number-\<build\_number\>'
+The following will create a tag '3.4.2-my-build-number-\<build\_number\>':
 
 ```yaml
-uses: marohrdanz/build-number-tag@main
+uses: marohrdanz/build-number-tag@v1.0.0
 with:
   prefix: '-my-build-number-'
   token: ${{ secrets.TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,34 +25,36 @@ this action  will create a new tag: 'build-4'.
 
 - `build_number`: New build number. Output in case subsequent workflow steps want to use it.
 
-## Example usage
+## Example Usage
 
-The following will create a tag 'build-\<build\_number\>':
+Here are three different examples of how to use this action.
 
-```yaml
-uses: marohrdanz/build-number-tag@v1.0.0
-with:
-  token: ${{ secrets.TOKEN }}
-```
+1. To create a tag 'build-\<build\_number\>':
 
-The following will create a tag 'my-build-number-\<build\_number\>':
+   ```yaml
+   uses: marohrdanz/build-number-tag@v1.0.0
+   with:
+     token: ${{ secrets.TOKEN }}
+   ```
 
-```yaml
-uses: marohrdanz/build-number-tag@v1.0.0
-with:
-  prefix: 'my-build-number-'
-  token: ${{ secrets.TOKEN }}
-```
+2. To create a tag 'my-build-number-\<build\_number\>':
 
-The following will create a tag '3.4.2-my-build-number-\<build\_number\>':
+   ```yaml
+   uses: marohrdanz/build-number-tag@v1.0.0
+   with:
+     prefix: 'my-build-number-'
+     token: ${{ secrets.TOKEN }}
+   ```
 
-```yaml
-uses: marohrdanz/build-number-tag@v1.0.0
-with:
-  prefix: '-my-build-number-'
-  token: ${{ secrets.TOKEN }}
-  version_prefix: "3.4.2"
-```
+3. To create a tag '3.4.2-my-build-number-\<build\_number\>':
+
+   ```yaml
+   uses: marohrdanz/build-number-tag@v1.0.0
+   with:
+     prefix: '-my-build-number-'
+     token: ${{ secrets.TOKEN }}
+     version_prefix: "3.4.2"
+   ```
 
 Heavily inspired by https://github.com/onyxmueller
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This action creates a tag with the build number in the repo, with optional versi
 
 ## Inputs
 
-- `prefix`: Prefix for tag. Default: 'build-number-'
+- `prefix`: Prefix for tag. Default: 'build-'
 - `token`: GitHub token to create tag
 - `version_prefix`: Optional prefix to prefix :laughing:
-  - This is for uses who want tags such as '\<version\_number\>-build-number-\<build\_number\>',    
+  - This is for uses who want tags such as '\<version\_number\>-build-\<build\_number\>',    
     e.g. '2.3.1-build-number-4'
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Create Build Number Tag
 
-This action creates a tag in the repo with the build number in the repo, with optional version number.
+This action creates a tag in the repo with the build number, and optional version number.
 
 To determine the build number, this action examines the existing tags in the repo matching the 
 prefix (default prefix 'build-'), finds the largest existing number, and increments it by 1.
 
-For example, if the repo has existing tags: 'build-1', 'build-2', 'build-3', this action 
-will create a new tag 'build-4'.
+For example, if the repo has existing tags: 
+
+- build-1
+- build-2
+- build-3
+
+this action  will create a new tag: 'build-4'.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Create Build Number Tag
 
-This action creates a tag with the build number in the repo, with optional version number.
+This action creates a tag in the repo with the build number in the repo, with optional version number.
+
+To determine the build number, this action examines the existing tags in the repo matching the 
+prefix (default prefix 'build-'), finds the largest existing number, and increments it by 1.
+
+For example, if the repo has existing tags: 'build-1', 'build-2', 'build-3', this action 
+will create a new tag 'build-4'.
 
 ## Inputs
 
@@ -12,7 +18,7 @@ This action creates a tag with the build number in the repo, with optional versi
 
 ## Outputs
 
-- `build_number`: New build number. Output in case subsequent steps want to use it
+- `build_number`: New build number. Output in case subsequent workflow steps want to use it.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ prefix (default prefix 'build-'), finds the largest existing number, and increme
 
 For example, if the repo has existing tags: 
 
-- build-1
-- build-2
-- build-3
+- *build-1*
+- *build-2*
+- *build-3*
 
 this action  will create a new tag: *build-4*.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Create Build Number Tag
 
-This action creates a tag with the build number in the repo.
+This action creates a tag with the build number in the repo, with optional version number.
 
 ## Inputs
 
 - `prefix`: Prefix for tag. Default: 'build-number-'
 - `token`: GitHub token to create tag
+- `version_prefix`: Optional prefix to prefix :laughing:
 
 ## Outputs
 
@@ -13,11 +14,23 @@ This action creates a tag with the build number in the repo.
 
 ## Example usage
 
+The following will create a tag 'my-build-number-\<build\_number\>'
+
 ```yaml
 uses: marohrdanz/build-number-tag@main
 with:
-  token: ${{ secrets.TOKEN }}
   prefix: 'my-build-number-'
+  token: ${{ secrets.TOKEN }}
+```
+
+The following will create a tag '3.4.2-build-number-\<build\_number\>'
+
+```yaml
+uses: marohrdanz/build-number-tag@main
+with:
+  prefix: '-build-number-'
+  token: ${{ secrets.TOKEN }}
+  version_prefix: "3.4.2"
 ```
 
 Heavily inspired by https://github.com/onyxmueller

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Create Build Number Tag
+# GitHub Action to Create Build Number Tag
 
-This action creates a tag in the repo with the build number, and optional version number.
+This action creates a tag in the repo with an incremental build number, and optional version number.
 
 To determine the build number, this action examines the existing tags in the repo matching the 
 prefix (default prefix 'build-'), finds the largest existing number, and increments it by 1.
@@ -11,7 +11,7 @@ For example, if the repo has existing tags:
 - build-2
 - build-3
 
-this action  will create a new tag: 'build-4'.
+this action  will create a new tag: *build-4*.
 
 ## Inputs
 
@@ -27,7 +27,7 @@ this action  will create a new tag: 'build-4'.
 
 ## Example Usage
 
-Here are three different examples of how to use this action.
+Below are three different examples of how to use this action.
 
 1. To create a tag 'build-\<build\_number\>':
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This action creates a tag with the build number in the repo, with optional versi
 - `prefix`: Prefix for tag. Default: 'build-number-'
 - `token`: GitHub token to create tag
 - `version_prefix`: Optional prefix to prefix :laughing:
+  - This is for uses who want tags such as '\<version\_number\>-build-number-\<build\_number\>',
+    e.g. '2.3.1-build-number-4'
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,21 @@ This action creates a tag with the build number in the repo, with optional versi
 - `token`: GitHub token to create tag
 - `version_prefix`: Optional prefix to prefix :laughing:
   - This is for uses who want tags such as '\<version\_number\>-build-\<build\_number\>',    
-    e.g. '2.3.1-build-number-4'
+    e.g. '2.3.1-build-4'
 
 ## Outputs
 
 - `build_number`: New build number. Output in case subsequent steps want to use it
 
 ## Example usage
+
+The following will create a tag 'build-\<build\_number\>'
+
+```yaml
+uses: marohrdanz/build-number-tag@main
+with:
+  token: ${{ secrets.TOKEN }}
+```
 
 The following will create a tag 'my-build-number-\<build\_number\>'
 
@@ -25,12 +33,12 @@ with:
   token: ${{ secrets.TOKEN }}
 ```
 
-The following will create a tag '3.4.2-build-number-\<build\_number\>'
+The following will create a tag '3.4.2-my-build-number-\<build\_number\>'
 
 ```yaml
 uses: marohrdanz/build-number-tag@main
 with:
-  prefix: '-build-number-'
+  prefix: '-my-build-number-'
   token: ${{ secrets.TOKEN }}
   version_prefix: "3.4.2"
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   prefix:
     description: 'Prefix for tag'
     required: false
-    default: 'build-number-'
+    default: 'build-'
   token:
     description: 'GitHub token to create and delete refs'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   token:
     description: 'GitHub token to create and delete refs'
     required: true
+  version_prefix:
+    description: 'Optional version number to prefix the prefix'
+    required: false
 outputs:
   build_number:
     description: 'Build tag number'

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const myToken = core.getInput('token');
 const octokit = github.getOctokit(myToken);
 const prefix = core.getInput('prefix');
 core.debug(`Tag prefix: ${prefix}`);
+const version_prefix = core.getInput('version_prefix');
+core.debug(`Version prefix for the tag: ${version_prefix}`);
 
 main();
 

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ async function main() {
     let build_number = getBuildNumber(tagsMatchingPrefix)
     let tagName;
     if (version_prefix != '') {
-      tagName = `${prefix}${build_number}`;
-    } else {
       tagName = `${version_prefix}${prefix}${build_number}`;
+    } else {
+      tagName = `${prefix}${build_number}`;
     }
     response = await createTag(tagName)
     core.notice(`Created new tag: ${tagName}`);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function main() {
     }
     response = await createTag(tagName)
     core.notice(`Created new tag: ${tagName}`);
-    core.notice(`Set action outpupt: build_number = ${build_number}`);
+    core.info(`Set action outpupt: build_number = ${build_number}`);
     core.setOutput("build_number", build_number);
   } catch(err) {
     core.error(err);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ async function main() {
     let allTags = await getAllTags();
     let tagsMatchingPrefix = getTagsMatchingPrefix(allTags)
     let build_number = getBuildNumber(tagsMatchingPrefix)
-    let tagName = `${prefix}${build_number}`;
+    let tagName;
+    if (version_prefix != '') {
+      tagName = `${prefix}${build_number}`;
+    } else {
+      tagName = `${version_prefix}${prefix}${build_number}`;
+    }
     response = await createTag(tagName)
     core.notice(`Created new tag: ${tagName}`);
     core.notice(`Set action outpupt: build_number = ${build_number}`);


### PR DESCRIPTION
There was a feature request to allow for tags such as:

2.34.2-build-4

This pull request allows for that providing an additional optional input `version_prefix` that to allow for that.